### PR TITLE
decode project-osrm routes

### DIFF
--- a/Polyline.encoded.js
+++ b/Polyline.encoded.js
@@ -78,12 +78,14 @@
 			return encoded_points;
 		},
 
-		decode: function (encoded) {
+		decode: function (encoded, precision) {
 			var len = encoded.length;
 			var index = 0;
 			var latlngs = [];
 			var lat = 0;
 			var lng = 0;
+			
+			precision = Math.pow(10, -precision);
 
 			while (index < len) {
 				var b;
@@ -107,7 +109,7 @@
 				var dlng = ((result & 1) ? ~(result >> 1) : (result >> 1));
 				lng += dlng;
 
-				latlngs.push([lat * 1e-5, lng * 1e-5]);
+				latlngs.push([lat * precision, lng * precision]);
 			}
 
 			return latlngs;


### PR DESCRIPTION
If you want to use the router from project-osrm you have to take into account that unlinke Google Maps the geometry is compressed with a precision of six digits.

It would be nice if you could specify the precision when calling decode.
