### PR TITLE
decode OSRM Routing Engine geometries

### DIFF
--- a/Polyline.encoded.js
+++ b/Polyline.encoded.js
@@ -58,17 +58,21 @@
 
 
 	var PolylineUtil = {
-		encode: function (latlngs) {
+		encode: function (latlngs, precision) {
 			var i, dlat, dlng;
 			var plat = 0;
 			var plng = 0;
 			var encoded_points = "";
 
+			if (typeof(precision) === 'undefined') precision = 5;
+
+			precision = Math.pow(10, precision);
+
 			for (i = 0; i < latlngs.length; i++) {
 				var lat = getLat(latlngs[i]);
 				var lng = getLng(latlngs[i]);
-				var late5 = Math.floor(lat * 1e5);
-				var lnge5 = Math.floor(lng * 1e5);
+				var late5 = Math.floor(lat * precision);
+				var lnge5 = Math.floor(lng * precision);
 				dlat = late5 - plat;
 				dlng = lnge5 - plng;
 				plat = late5;
@@ -78,12 +82,16 @@
 			return encoded_points;
 		},
 
-		decode: function (encoded) {
+		decode: function (encoded, precision) {
 			var len = encoded.length;
 			var index = 0;
 			var latlngs = [];
 			var lat = 0;
 			var lng = 0;
+
+			if (typeof(precision) === 'undefined') precision = 5;
+
+			precision = Math.pow(10, -precision);
 
 			while (index < len) {
 				var b;
@@ -107,7 +115,7 @@
 				var dlng = ((result & 1) ? ~(result >> 1) : (result >> 1));
 				lng += dlng;
 
-				latlngs.push([lat * 1e-5, lng * 1e-5]);
+				latlngs.push([lat * precision, lng * precision]);
 			}
 
 			return latlngs;

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This Leaflet plugin extends the [Leaflet](https://github.com/CloudMade/Leaflet) 
 	<th colspan="2">Utility methods</th>
 </tr>
 <tr>
-	<td><code>L.PolylineUtil.encode(latlngs)</code></td>
+	<td><code>L.PolylineUtil.encode(latlngs [, precision])</code></td>
 	<td>Encode an array of <code>L.LatLng</code> objects,
 	or an array of arrays.</td>
 </tr>
 <tr>
-	<td><code>L.PolylineUtil.decode(encoded)</code></td>
+	<td><code>L.PolylineUtil.decode(encoded [, precision])</code></td>
 	<td>Decode the string <code>encoded</code> to an array of <code>[lat, lng]</code>-arrays.</td>
 </tr>
 
@@ -68,6 +68,16 @@ var polyline = L.Polyline.fromEncoded(encoded);
 // prints an array of 3 LatLng objects.
 console.log(polyline.getLatLngs());
 ```
+
+Use a decoding precision of 6 to decode OSRM Routing Engine geometries
+```javascript
+var encoded = "_izlhA~pvydF_{geC~{mZ_kwzCn`{nI";
+var polyline = new L.Polyline(PolylineUtil.decode(encoded, 6));
+
+// prints an array of 3 LatLng objects.
+console.log(polyline.getLatLngs());
+```
+
 
 ### Node package
 You can use `encode()` and `decode()` in your Nodejs scripts:

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,9 @@ var latlngs = [
 	[40.7, -120.95],
 	[43.252, -126.453]
 ];
+
 var encoded = '_p~iF~cn~U_ulLn{vA_mqNvxq`@';
+var encoded6 = '_izlhA~pvydF_{geC~{mZ_kwzCn`{nI';
 
 describe('Polyline', function () {
 
@@ -16,8 +18,20 @@ describe('Polyline', function () {
 		expect(polyUtil.encode(latlngs)).to.eql(encoded);
 	});
 
+	it('encodes6', function () {
+		expect(polyUtil.encode(latlngs, 6)).to.eql(encoded6);
+	});
+
 	it('decodes', function () {
 		var decoded = polyUtil.decode(encoded);
+
+		for (var i in decoded) {
+			expect(decoded[i][0]).to.be.within(latlngs[i][0] - d, latlngs[i][0] + d);
+		}
+	});
+
+	it('decodes6', function () {
+		var decoded = polyUtil.decode(encoded6, 6);
 
 		for (var i in decoded) {
 			expect(decoded[i][0]).to.be.within(latlngs[i][0] - d, latlngs[i][0] + d);


### PR DESCRIPTION
Added precision parameter to be able to decode OSRM Routing Engine geometries that use a geometry encoding precision of 6 instead the default Google precision of 5.
